### PR TITLE
feat(products): add test endpoint with margin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# API keys
+OPENAI_API_KEY=changeme
+SHOPIFY_API_KEY=changeme
+TIKTOK_COOKIE=changeme
+
+# E-commerce settings
+DEFAULT_MARGIN_PERCENT=20

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,6 +1,10 @@
+import os
 from pydantic import BaseModel
+
 
 class Settings(BaseModel):
     artifacts_dir: str = "artifacts"
+    default_margin_percent: float = float(os.getenv("DEFAULT_MARGIN_PERCENT", 20))
+
 
 settings = Settings()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from .routers import lyrics, music, cover, video, system
+from .routers import lyrics, music, cover, video, system, products
 
 app = FastAPI()
 
@@ -8,6 +8,7 @@ app.include_router(music.router, prefix="/api/music")
 app.include_router(cover.router, prefix="/api/cover")
 app.include_router(video.router, prefix="/api/video")
 app.include_router(system.router, prefix="/api/system")
+app.include_router(products.router, prefix="/api/products")
 
 
 @app.get("/")

--- a/api/app/routers/products.py
+++ b/api/app/routers/products.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from ..config import settings
+
+
+router = APIRouter()
+
+
+class Product(BaseModel):
+    name: str
+    cost: float
+
+
+class ProductResponse(Product):
+    price: float
+    marginPercent: float
+
+
+@router.post("/test", response_model=ProductResponse)
+def test_product(product: Product) -> ProductResponse:
+    margin = settings.default_margin_percent / 100.0
+    price = product.cost * (1 + margin)
+    return ProductResponse(
+        name=product.name,
+        cost=product.cost,
+        price=price,
+        marginPercent=settings.default_margin_percent,
+    )

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
-import os, sys, pathlib
+import os
+import sys
+import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from api.app.main import app
 

--- a/api/tests/test_products.py
+++ b/api/tests/test_products.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+import pathlib, sys
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app.main import app
+
+client = TestClient(app)
+
+def test_product_margin():
+    r = client.post('/api/products/test', json={'name': 'widget', 'cost': 100})
+    assert r.status_code == 200
+    data = r.json()
+    assert data['price'] == 120.0
+    assert data['marginPercent'] == 20.0

--- a/api/tests/test_products.py
+++ b/api/tests/test_products.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
-import pathlib, sys
+import pathlib
+import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from api.app.main import app
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,26 +6,31 @@
    git clone <repo>
    cd whisper-os
    ```
-2. Run setup script
+2. Copy `.env.example` to `.env.local` and edit required keys
+   ```powershell
+   Copy-Item .env.example .env.local
+   ```
+3. Run setup script
    ```powershell
    .\scripts\setup.ps1
    ```
-3. Verify installation
+4. Verify installation
    ```powershell
    pytest
    npm run build
    ```
-4. Start development servers
+5. Start development servers
    ```powershell
    .\scripts\dev.ps1
    ```
-5. Visit UI at http://localhost:5173 and API health at http://localhost:8080/api/system/health
+6. Visit UI at http://localhost:5173 and API health at http://localhost:8080/api/system/health
 
 ## Linux / macOS
 1. Clone repository
    ```bash
    git clone <repo>
    cd whisper-os
+   cp .env.example .env.local
    python -m venv .venv
    source .venv/bin/activate
    pip install -r api/requirements.txt


### PR DESCRIPTION
## Summary
- add `/api/products/test` endpoint that returns price with configurable margin
- load `DEFAULT_MARGIN_PERCENT` from env
- document env setup in quickstart

## Testing
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c46f8635e8832cbeb4675ec5cb0372