### PR TITLE
Add venv creation check to Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ For quick setup instructions, see [docs/QUICKSTART.md](docs/QUICKSTART.md).
     - Open `.env.local` and replace `REPLACE_WITH_YOUR_KEY` with your Google Gemini API key. Other keys can be configured later via the UI.
     - Set your desired defaults for chunked rendering and auto-fallback.
 
-3.  **Run the Development Environment (One-Click):**
+3.  **Install Dependencies:**
+    ```powershell
+    # From the project root directory
+    powershell -ExecutionPolicy Bypass -File .\windows\install.ps1
+    ```
+    The script creates a `.venv` if missing and installs Python requirements using `py`.
+
+4.  **Run the Development Environment (One-Click):**
     This single orchestrator script handles everything: it creates virtual environments, installs all Python and Node.js dependencies, and starts both backend servers and the frontend development server concurrently.
 
     Open PowerShell and run:
@@ -67,7 +74,7 @@ For quick setup instructions, see [docs/QUICKSTART.md](docs/QUICKSTART.md).
     - The **ACE-Step API** will start on `http://127.0.0.1:8001`.
     - The **Frontend UI** will be available at `http://localhost:5173`.
 
-4. **Stop All Services:**
+5. **Stop All Services:**
    To stop all running processes gracefully, use the `stop-all.ps1` script:
     ```powershell
     # From the project root directory

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,9 +10,9 @@
    ```powershell
    Copy-Item .env.example .env.local
    ```
-3. Run setup script
+3. Install dependencies
    ```powershell
-   .\scripts\setup.ps1
+   powershell -ExecutionPolicy Bypass -File .\windows\install.ps1
    ```
 4. Verify installation
    ```powershell

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -1,0 +1,36 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# Ensure Python launcher is available
+if (-not (Get-Command py -ErrorAction SilentlyContinue)) {
+    Write-Error 'Python is not installed or not found in PATH. Please install Python 3.11.'
+    exit 1
+}
+
+$venvPath = Join-Path $PSScriptRoot '.venv'
+$pythonExe = Join-Path $venvPath 'Scripts/python.exe'
+
+if (-not (Test-Path $venvPath)) {
+    Write-Host 'Creating virtual environment...'
+    try {
+        py -m venv $venvPath
+    } catch {
+        Write-Error "Failed to create virtual environment: $_"
+        exit 1
+    }
+}
+
+if (-not (Test-Path $pythonExe)) {
+    Write-Error "Virtual environment not found at $pythonExe"
+    exit 1
+}
+
+Write-Host 'Installing Python dependencies...'
+& $pythonExe -m pip install -r (Join-Path $PSScriptRoot '..\\api\\requirements.txt')
+if ($LASTEXITCODE -ne 0) {
+    Write-Error 'Dependency installation failed.'
+    exit $LASTEXITCODE
+}
+
+Write-Host 'Installation complete.'


### PR DESCRIPTION
## Summary
- ensure `windows/install.ps1` creates and validates `.venv` before installing dependencies
- document new Windows install step in README and Quickstart

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c484eb7454832ca8f3e16916e58aad