### PR TITLE
docs: add repository health report and fix plan

### DIFF
--- a/docs/fix-plan.md
+++ b/docs/fix-plan.md
@@ -1,0 +1,22 @@
+# Fix Plan (Prioritized)
+
+1. **Lock Dependencies**
+   - Generate `package-lock.json` or `pnpm-lock.yaml` for the front‑end and a `requirements.txt` for the Python backend to ensure reproducible installs.
+2. **Configuration Framework**
+   - Create `/config` with `settings.default.yaml`, `settings.local.yaml` (git‑ignored), and `settings.schema.json`.
+   - Provide `.env.example` with placeholders for API keys and services.
+3. **Config Loader**
+   - Implement a loader that merges defaults → environment → local overrides and validates against the schema.
+4. **Orchestrator Skeleton**
+   - Establish `/orchestrator` module with task bus and pluggable agents (music, social, e‑commerce, analytics).
+5. **Dashboard Foundation**
+   - Scaffold React dashboard (`/app/dashboard`) with toggles for modules and live log placeholder.
+6. **Windows‑First Scripts**
+   - Expand `scripts/` with `preflight.ps1`, `run.ps1`, and matching `.sh` notes for Linux users.
+7. **Continuous Integration**
+   - Add GitHub Actions for linting, type checking, and pytest.
+8. **Testing Expansion**
+   - Add unit tests for the config loader and orchestrator stubs; introduce front‑end tests.
+9. **Documentation**
+   - Update `docs/QUICKSTART.md` after setup changes and add architecture, operations, and security docs.
+

--- a/docs/repo-health.md
+++ b/docs/repo-health.md
@@ -1,0 +1,35 @@
+# Repository Health Report
+
+## Overview
+Whisper OS combines a FastAPI backend and a TypeScript/React front‑end for AI‑driven music creation. The project is intended to run natively on Windows but is currently being developed in a mixed environment.
+
+## Structure
+- **api/** – FastAPI application with initial routes and tests.
+- **agents/** and assorted `*-module.ts` files – front‑end modules and utilities for music, social, and ecommerce features.
+- **scripts/** – PowerShell helpers (`setup.ps1`, `dev.ps1`).
+- **docs/** – currently only `QUICKSTART.md` plus newly added reports.
+
+## Build & Run Scripts
+- Node scripts: `npm run dev`, `npm run build`, `npm run typecheck`.
+- Python API run instructions are not formalized beyond tests.
+- PowerShell scripts provide basic setup and dev commands but lack Linux equivalents.
+
+## Dependencies
+- **Node**: dependencies use floating versions (`^`) and no lock file is present, making builds non‑reproducible.
+- **Python**: only a `constraints.txt` exists; full requirements are missing.
+
+## Testing & Linting
+- `pytest` suite in `api/tests` (6 tests) passes.
+- No front‑end or integration tests.
+- No linting or formatting tooling defined for either stack.
+
+## Documentation & CI
+- `docs/QUICKSTART.md` covers setup but broader architecture and operations docs are absent.
+- No GitHub Actions or other CI/CD pipeline is configured.
+
+## Secrets & Configuration
+- Repository lacks a `.env.example` and structured configuration loader, increasing risk of misconfigured secrets.
+
+## OS Compatibility
+- Windows PowerShell scripts exist, but cross‑platform support and Windows validation scripts are incomplete.
+


### PR DESCRIPTION
## Summary
- document current repository structure, dependencies, and test status in new repo health report
- propose prioritized roadmap and fix plan for upcoming phases

## Testing
- `npm run typecheck`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5066fa8b4832ca93a0e95e669aa34