### PR TITLE
Add Celery tasks for music and video generation

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -1,0 +1,12 @@
+import os
+from celery import Celery
+
+redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+celery_app = Celery(
+    "whisper_os",
+    broker=redis_url,
+    backend=redis_url,
+)
+
+celery_app.conf.task_always_eager = os.getenv("CELERY_TASK_ALWAYS_EAGER") == "1"

--- a/api/app/routers/music.py
+++ b/api/app/routers/music.py
@@ -1,20 +1,10 @@
 from fastapi import APIRouter
-from uuid import uuid4
-from pathlib import Path
 from ..schemas import MusicGenerateRequest, MusicGenerateResponse
-from ..config import settings
+from ..tasks import generate_music_task
 
 router = APIRouter()
 
-ART_DIR = Path(settings.artifacts_dir) / "music"
-ART_DIR.mkdir(parents=True, exist_ok=True)
-
 @router.post("/generate", response_model=MusicGenerateResponse)
 def generate_music(req: MusicGenerateRequest) -> MusicGenerateResponse:
-    uid = uuid4().hex
-    wav_path = ART_DIR / f"{uid}.wav"
-    mp3_path = ART_DIR / f"{uid}.mp3"
-    wav_path.write_bytes(b"fake wav")
-    mp3_path.write_bytes(b"fake mp3")
-    report = {"status": "ok", "prompt": req.prompt, "model": req.model}
-    return MusicGenerateResponse(wavPath=str(wav_path), mp3Path=str(mp3_path), report=report)
+    res = generate_music_task.delay(req.prompt, req.durationSec, req.model).get()
+    return MusicGenerateResponse(**res)

--- a/api/app/routers/video.py
+++ b/api/app/routers/video.py
@@ -1,17 +1,10 @@
 from fastapi import APIRouter
-from uuid import uuid4
-from pathlib import Path
 from ..schemas import VideoRenderRequest, VideoRenderResponse
-from ..config import settings
+from ..tasks import render_video_task
 
 router = APIRouter()
 
-ART_DIR = Path(settings.artifacts_dir) / "video"
-ART_DIR.mkdir(parents=True, exist_ok=True)
-
 @router.post("/render", response_model=VideoRenderResponse)
 def render_video(req: VideoRenderRequest) -> VideoRenderResponse:
-    uid = uuid4().hex
-    vid_path = ART_DIR / f"{uid}.mp4"
-    vid_path.write_bytes(b"")
-    return VideoRenderResponse(videoPath=str(vid_path))
+    res = render_video_task.delay(req.audioPath, req.preset).get()
+    return VideoRenderResponse(**res)

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from uuid import uuid4
+from .celery_app import celery_app
+from .config import settings
+
+@celery_app.task(name="music.generate")
+def generate_music_task(prompt: str, duration_sec: int, model: str):
+    art_dir = Path(settings.artifacts_dir) / "music"
+    art_dir.mkdir(parents=True, exist_ok=True)
+    uid = uuid4().hex
+    wav_path = art_dir / f"{uid}.wav"
+    mp3_path = art_dir / f"{uid}.mp3"
+    wav_path.write_bytes(b"fake wav")
+    mp3_path.write_bytes(b"fake mp3")
+    report = {"status": "ok", "prompt": prompt, "model": model}
+    return {"wavPath": str(wav_path), "mp3Path": str(mp3_path), "report": report}
+
+@celery_app.task(name="video.render")
+def render_video_task(audio_path: str, preset: str):
+    art_dir = Path(settings.artifacts_dir) / "video"
+    art_dir.mkdir(parents=True, exist_ok=True)
+    uid = uuid4().hex
+    vid_path = art_dir / f"{uid}.mp4"
+    vid_path.write_bytes(b"")
+    return {"videoPath": str(vid_path)}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,6 @@ pydantic
 httpx
 pytest
 torch; extra == "gpu"
+
+celery
+redis

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 import os
 import sys
 import pathlib
+os.environ.setdefault("CELERY_TASK_ALWAYS_EAGER", "1")
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from api.app.main import app
 

--- a/api/tests/test_tasks.py
+++ b/api/tests/test_tasks.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pathlib
+os.environ.setdefault("CELERY_TASK_ALWAYS_EAGER", "1")
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app.tasks import generate_music_task, render_video_task
+from api.app.config import settings
+
+
+def test_generate_music_task(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "artifacts_dir", str(tmp_path))
+    res = generate_music_task.delay("beat", 5, "model").get()
+    wav = pathlib.Path(res["wavPath"])
+    mp3 = pathlib.Path(res["mp3Path"])
+    assert wav.exists()
+    assert mp3.exists()
+
+
+def test_render_video_task(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "artifacts_dir", str(tmp_path))
+    res = render_video_task.delay("a.wav", "preset").get()
+    vid = pathlib.Path(res["videoPath"])
+    assert vid.exists()

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,7 +23,11 @@
    ```powershell
    .\scripts\dev.ps1
    ```
-6. Visit UI at http://localhost:5173 and API health at http://localhost:8080/api/system/health
+6. In another terminal, start the Celery worker
+   ```powershell
+   .\scripts\worker.ps1
+   ```
+7. Visit UI at http://localhost:5173 and API health at http://localhost:8080/api/system/health
 
 ## Linux / macOS
 1. Clone repository
@@ -41,8 +45,9 @@
    pytest
    npm run build
    ```
-3. Start servers
+3. Start servers (run each in its own shell)
    ```bash
    uvicorn api.app.main:app --reload --port 8080 &
+   ./scripts/worker.sh &
    npm run dev
    ```

--- a/scripts/worker.ps1
+++ b/scripts/worker.ps1
@@ -1,0 +1,2 @@
+cd $PSScriptRoot\..
+python -m celery -A api.app.celery_app:celery_app worker --loglevel=INFO

--- a/scripts/worker.sh
+++ b/scripts/worker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+python -m celery -A api.app.celery_app:celery_app worker --loglevel=INFO


### PR DESCRIPTION
## Summary
- add celery/redis dependencies and initialization
- move music and video processing to Celery tasks
- document and script worker startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5065f5f78832ca81b4027dda62be5